### PR TITLE
Support for remote run arguments (these will ovveride command line args)

### DIFF
--- a/sushibar/dashboard/templates/pages/home.html
+++ b/sushibar/dashboard/templates/pages/home.html
@@ -145,7 +145,7 @@
         <p>Chef Name: <a href="{{channel.chef_link}}">{{channel.chef_name}}</a></p>
         <p>Run Options:
           <!-- <code>{{channel.cl_flags}}</code> -->
-          <label class="run-option"><input type="checkbox" id="update-run-option"> Update</label>
+          <label class="run-option"><input type="checkbox" id="update-run-option" checked="checked"> Update</label>
           <label class="run-option"><input type="checkbox" id="stage-run"> Stage</label>
           <label class="run-option"><input type="checkbox" id="publish-run"> Publish</label>
         </p>

--- a/sushibar/static/js/dashboard.js
+++ b/sushibar/static/js/dashboard.js
@@ -17,12 +17,18 @@ $(function() {
           // TODO: change icon to indicate it's running...
       }
 
-      // POST
+      // build URL for control endpoint
       var channel_control_url = "/api/channels/" + channel_id + "/control/";
-      // post_data = {"command":"start", "options": JSON.stringify({"--publish": false}) }
+
+      // extract args from modaal's checkboxes state
+      var cur_modal = $('div.action-modal.show');  // get the modal for current channel
       post_data = {
         "command": "start",
-        "args": JSON.stringify({}),
+        "args": JSON.stringify({
+          update: cur_modal.find('input#update-run-option').get(0).checked,
+          stage: cur_modal.find('input#stage-run').get(0).checked,
+          publish: cur_modal.find('input#publish-run').get(0).checked
+        }),
         "options": JSON.stringify({})
       }
       $.post(channel_control_url, post_data, toggleRestartButton);


### PR DESCRIPTION
Added support for the checkboxes on the start modal for `--daemon`ized chefs.

Arguments sent by sushibar have precedence over commands specified on command line.

I'm not sure if update should be checked by default. On the command line `--update` is [not on by default](https://github.com/learningequality/ricecooker/blob/master/ricecooker/chefs.py#L56) but I think it makes sense if you running once every month to run with `--update`. @jayoshih what do you think?