### PR TITLE
Turned on HTTP-->HTTPS redirect. Seems to work

### DIFF
--- a/production.yml
+++ b/production.yml
@@ -52,7 +52,7 @@ services:
       - VIRTUAL_PORT=6000
       - ASGI_UPSTREAM_NAME=sushibar_asgi_upstream
       - VIRTUAL_PROTO=http
-      - HTTPS_METHOD=noredirect
+      - HTTPS_METHOD=redirect
 
   asgi-worker:
     container_name: asgi-worker


### PR DESCRIPTION
This two-character change in the docker compose file resutls in the following change in the nginx config file.

BEFORE
```
# HTTPS_METHOD=noredirect
server {
  server_name sushibar.learningequality.org;
  listen 80 ;
  access_log /var/log/nginx/access.log vhost;
  include /etc/nginx/vhost.d/default;
  location / {
    proxy_pass http://sushibar.learningequality.org;
  }
}
```

AFTTER
```
# HTTPS_METHOD=redirect start
server {
  server_name sushibar.learningequality.org;
  listen 80 ;
  access_log /var/log/nginx/access.log vhost;
  return 301 https://$host$request_uri;
}
```

which is what we want...